### PR TITLE
multicast_iface config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ environment:
   Specifies the multicast address to be used for node discovery when using
   the `multicast` protocol. Default is `{239, 192, 0, 1}`.
 
+* `{multicast_iface, MulticastAddr :: inet:ip4_address()}`
+
+  The address of the interface to listen on for multicast packets.
+  Default is `{0, 0, 0, 0}`, which mostly works unless you're
+  multi-homed.  See `IP_ADD_MEMBERSHIP` in the `ip(7)` man page.
+
 * `{multicast_ttl, non_neg_integer()}`
 
   Specifies the time-to-live (TTL) of outgoing multicast packets. When setting

--- a/src/bootstrap.app.src
+++ b/src/bootstrap.app.src
@@ -40,6 +40,7 @@
     {secondary_ports, [50338, 50339]},
     {ping_timeout, 10000},
     {multicast_ip, {239, 192, 0, 1}},
+    {multicast_iface, {0, 0, 0, 0}},
     {multicast_ttl, 1}
    ]},
   {maintainers, ["Tobias Schlager"]},

--- a/src/bootstrap_multicast.erl
+++ b/src/bootstrap_multicast.erl
@@ -36,7 +36,8 @@
 %%------------------------------------------------------------------------------
 options() ->
     Addr = bootstrap_lib:get_env(multicast_ip),
-    [{add_membership, {Addr, {0, 0, 0, 0}}},
+    Iface = bootstrap_lib:get_env(multicast_iface, {0, 0, 0, 0}),
+    [{add_membership, {Addr, Iface}},
      {multicast_ttl, bootstrap_lib:get_env(multicast_ttl)},
      {multicast_loop, true}].
 


### PR DESCRIPTION
Thanks or this!  I've been looking for a way to autodiscover nodes.

I'm testing it by running a cluster of dockert containers, and I ran into a couple of problems:
1. docker sets the broadcast address to 0.0.0.0 for containers so the broadcast UDP never makes it out
2. using the default iface address for 0.0.0.0 IP_ADD_MEMBERSHIP doesn't bind to the right address on the docker host, so I needed to add a config parameter for it, hence this PR.

Cheers,
~~
Noel
